### PR TITLE
Add Yarn to Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM ruby:2.4.1
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev apt-transport-https
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update && apt-get install -y yarn nodejs
 RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
+RUN yarn install
 ADD . /myapp
 CMD bundle exec rails s

--- a/README.md
+++ b/README.md
@@ -53,15 +53,7 @@ environment:
 ```
 $ cd ~/path/to/my/application
 $ docker-compose run --rm web /bin/bash
-# rails db:create
-# rails db:schema:load
-```
-
-Optionally, run the seeds to already have an initial user and if you don't
-need to test the onboarding:
-
-```
-# rails db:seed
+# rails db:setup
 ```
 
 Open up another tab in your terminal, or exit the shell session inside the
@@ -76,8 +68,21 @@ $ docker-compose up
 To stop your local development environment again where you're finished working:
 
 ```
-$ docker-compose down
+$ docker-compose stop
 ```
+
+### Migrating, running tests, etc.
+
+To do any regular Rails task like creating migrations, running tests, or
+generating models and controllers, you can use the following command to
+keep a development shell open inside the Rails environment:
+
+```
+$ docker-compose run --rm web /bin/bash
+```
+
+Recommended is to just keep this command open in a terminal so that you
+can always access development tasks in Rails.
 
 ### Running tests
 


### PR DESCRIPTION
This PR adds Yarn commands to the standard Dockerfile build and updates the README to simplify and explain how local development can work. 

Most importantly, running seperate `db:create` and `db:schema:load` is replaced with `db:setup` so it runs all DB-related tasks, including running seeds.

Also updated the README about running the local development shell.